### PR TITLE
Scripts: sarch for fades in $PATH

### DIFF
--- a/raw/download_images.py
+++ b/raw/download_images.py
@@ -1,4 +1,4 @@
-#!/usr/bin/fades
+#!/usr/bin/env fades
 
 import json
 import os

--- a/raw/fill_country_info.py
+++ b/raw/fill_country_info.py
@@ -1,4 +1,4 @@
-#!/usr/bin/fades
+#!/usr/bin/env fades
 
 import json
 import os

--- a/raw/get_coi_data.py
+++ b/raw/get_coi_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/fades
+#!/usr/bin/env fades
 
 import json
 

--- a/raw/get_countries_data.py
+++ b/raw/get_countries_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/fades
+#!/usr/bin/env fades
 
 import json
 


### PR DESCRIPTION
Improve the shebang in scripts for portability. Using /usr/bin/env
makes sure fades can be anywhere in $PATH. For instance, when
installing with pip as: `pip install --user fades`.